### PR TITLE
Adjust CNN visualization colors

### DIFF
--- a/convoluational_neural_network_visualizzation.tex
+++ b/convoluational_neural_network_visualizzation.tex
@@ -6,29 +6,12 @@
 \usetikzlibrary{3d} %for including external image 
 
 
-\definecolor{ConvColor}{HTML}{4CAF50}
-\definecolor{ConvReluColor}{HTML}{4CAF50}
-\definecolor{PoolColor}{HTML}{B0BEC5}
-\definecolor{UnpoolColor}{HTML}{B39DDB}
-\definecolor{FcColor}{HTML}{1976D2}
-\definecolor{FcReluColor}{HTML}{1976D2}
-\definecolor{DcnvColor}{HTML}{1976D2}
-\definecolor{SoftmaxColor}{HTML}{1976D2}
-\definecolor{SumColor}{HTML}{FFB300}
-\definecolor{PostConvColor}{HTML}{1976D2}
-
-\def\ConvColor{ConvColor}
-\def\ConvReluColor{ConvReluColor}
-\def\PoolColor{PoolColor}
-\def\UnpoolColor{UnpoolColor}
-\def\FcColor{FcColor}
-\def\FcReluColor{FcReluColor}
-\def\DcnvColor{DcnvColor}
-\def\SoftmaxColor{SoftmaxColor}
-\def\SumColor{SumColor}
-\def\PostConvColor{PostConvColor}
-
-\def\DcnvColor{rgb:blue,5;green,2.5;white,5}
+\def\ConvColor{rgb:orange,5;red,3;white,5}
+\def\ConvReluColor{rgb:orange,5;red,5;white,5}
+\def\PoolColor{rgb:green,2;black,0.3}
+\def\SoftmaxColor{rgb:cyan,5;black,7}
+\def\SumColor{rgb:purple,5;green,10}
+\def\DcnvColor{rgb:blue,2;green,4;white,5}
 \newcommand{\copymidarrow}{\tikz \draw[-Stealth,line width=0.8mm,draw={rgb:blue,4;red,1;green,1;black,3}] (-0.3,0) -- ++(0.3,0);}
 
 \begin{document}

--- a/pyexamples/convoluational_neural_network_visualizzation.py
+++ b/pyexamples/convoluational_neural_network_visualizzation.py
@@ -21,7 +21,13 @@ def build_arch(img_node):
     return [
         to_head('..'),
         to_cor(),
-        r'\def\DcnvColor{rgb:blue,5;green,2.5;white,5}',  # colore deconv
+        # Palette colori come nell'esempio fornito (immagine con il gattino)
+        r'\def\ConvColor{rgb:orange,5;red,3;white,5}',
+        r'\def\ConvReluColor{rgb:orange,5;red,5;white,5}',
+        r'\def\PoolColor{rgb:green,2;black,0.3}',
+        r'\def\SoftmaxColor{rgb:cyan,5;black,7}',
+        r'\def\SumColor{rgb:purple,5;green,10}',
+        r'\def\DcnvColor{rgb:blue,2;green,4;white,5}',
         to_begin(),
 
         # immagine di input scelta dall'utente


### PR DESCRIPTION
## Summary
- align the CNN visualization color palette with the provided reference by overriding the convolution, pooling, deconvolution, softmax, and sum colors in both the standalone TeX file and the Python generator
- ensure the generated diagram matches the orange and complementary tones showcased in the reference image

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da90f9b32883318bf664bdceac89d9