### PR TITLE
Adjust CNN visualization colors to orange palette

### DIFF
--- a/pyexamples/convoluational_neural_network_visualizzation.py
+++ b/pyexamples/convoluational_neural_network_visualizzation.py
@@ -17,11 +17,11 @@ def build_arch(img_node):
     return [
         to_head('..'),
         to_cor(),
-        r'\def\ConvColor{rgb:orange,5;red,2.5;white,5}',
-        r'\def\ConvReluColor{rgb:orange,5;red,5;white,5}',
-        r'\def\PoolColor{rgb:green,2;black,0.3}',
+        r'\def\ConvColor{rgb:yellow,5;red,2.5;white,5}',
+        r'\def\ConvReluColor{rgb:yellow,5;red,5;white,5}',
+        r'\def\PoolColor{rgb:orange,5;red,3;white,3}',
         r'\def\SoftmaxColor{rgb:purple,5;black,7}',
-        r'\def\SumColor{rgb:green,5;black,7}',
+        r'\def\SumColor{rgb:orange,5;red,4;white,3}',
         r'\def\DcnvColor{rgb:blue,5;green,2.5;white,5}',
         to_begin(),
 


### PR DESCRIPTION
## Summary
- update the convolution, convolution+ReLU, pooling, and sum colors used in the CNN visualization example
- switch the green highlights to a darker orange palette to match the desired reference image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da9a38c4b48331a2b76ccdc8149b86